### PR TITLE
`check-md5`: Adding directive in case of error during mod maker parsing

### DIFF
--- a/launcher/commands/check.py
+++ b/launcher/commands/check.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from sys import stderr
 
 from launcher.commands.common import read_mod_maker, parse_moddb_data
 from launcher.downloader import download_mod
@@ -67,10 +68,14 @@ class CheckMD5:
         self._dl_dir = self._gamma / "downloads"
         modpack_data_dir = self._gamma / ".Grok's Modpack Installer" / "G.A.M.M.A" / "modpack_data"
 
-        mod_maker = read_mod_maker(
-            modpack_data_dir / 'modlist.txt',
-            modpack_data_dir / 'modpack_maker_list.txt'
-        )
+        try:
+            mod_maker = read_mod_maker(
+                modpack_data_dir / 'modlist.txt',
+                modpack_data_dir / 'modpack_maker_list.txt'
+            )
+        except FileNotFoundError:
+            print("Failure to read mod maker data, please run full-install once before using check-md5", file=stderr)
+            return
 
         print('-- Starting MD5 Check')
         for i in filter(lambda v: v and v['info_url'], mod_maker.values()):

--- a/launcher/commands/check.py
+++ b/launcher/commands/check.py
@@ -62,7 +62,7 @@ class CheckMD5:
         if not self._test_hash(file, hash):
             self.register_err(f"Failed to download missing file - {file.name}")
 
-    def run(self, args) -> None:
+    def run(self, args) -> None:  # noqa: C901
         self._gamma = Path(args.gamma)
         self._update_cache = args.update_cache
         self._dl_dir = self._gamma / "downloads"


### PR DESCRIPTION
Resolve #49 