### PR TITLE
Adding a method to fix malformed archive

### DIFF
--- a/launcher/commands/install.py
+++ b/launcher/commands/install.py
@@ -110,6 +110,19 @@ class FullInstall:
                 nfolder.mkdir(parents=True, exist_ok=True)
                 file.rename(nfolder / file.name)
 
+    def _fix_malformed_archive(self, dir: Path) -> None:
+        # Do not exec this on windows
+        if os_name == 'nt':
+            return
+
+        for path in dir.glob('*.*'):
+            if '\\' not in path.name:
+                continue
+
+            p = dir / path.name.replace('\\', '/')
+            p.parent.mkdir(parents=True, exist_ok=True)
+            path.rename(dir / p)
+
     def _install_mod(self, name: str, m: dict) -> None:
         install_dir = self._mod_dir / name
 
@@ -135,6 +148,7 @@ class FullInstall:
         with TemporaryDirectory(prefix="gamma-launcher-modinstall-") as dir:
             pdir = Path(dir)
             extract_archive(file, dir)
+            self._fix_malformed_archive(pdir)
             self._fix_path_case(pdir)
 
             iterator = [pdir] + ([Path(dir) / i for i in install_directives] if install_directives else [])


### PR DESCRIPTION
According to #55, some mods were unable to install properly.

This was caused by an issue on the Zip file where every path was Windows encoded:
```
      594  06-04-2023 18:45   PAW\Main\gamedata\configs\misc\task\tm_placeable_waypoints.ltx
     3898  06-19-2023 22:13   PAW\Main\gamedata\configs\scripts\paw\icons.ltx
      311  06-05-2023 12:08   PAW\Main\gamedata\configs\scripts\paw\icon_sets.ltx
      500  06-19-2023 22:12   PAW\Main\gamedata\configs\scripts\paw\icon_set_bodies.ltx
      625  06-05-2023 12:06   PAW\Main\gamedata\configs\scripts\paw\icon_set_bwhr.ltx
      679  06-04-2023 20:37   PAW\Main\gamedata\configs\scripts\paw\icon_set_faves.ltx
      412  05-21-2023 14:32   PAW\Main\gamedata\configs\scripts\paw\icon_set_patches.ltx
      587  06-05-2023 12:07   PAW\Main\gamedata\configs\scripts\paw\icon_set_pins.ltx
     4172  09-12-2023 00:15   PAW\Main\gamedata\configs\scripts\paw\menu_actions.ltx
```

There is no folder here, only 'files', recreating directory structure fix the issue.

Known affected archive:

  * Catspaw_Fair_Fast_Travel-2.3.3.zip
  * Catspaw_Personal_Adjustable_Waypoint-1.7.5.zip