### PR TITLE
fix: match parameter name to value usage

### DIFF
--- a/launcher/commands/install.py
+++ b/launcher/commands/install.py
@@ -75,12 +75,12 @@ class AnomalyInstall:
         metadata = parse_moddb_data(c_data.get("moddb_page"))
         return download_archive(c_data.get("dl_link"), self._cache_dir, hash=metadata.get('MD5 Hash'))
 
-    def _install_component(self, comp: str, ext: str = None) -> None:
+    def _install_component(self, comp: str, mime: str = None) -> None:
         c = self.files.get(comp)
         file = self._dl_component(c)
 
         print("  - Extracting")
-        extract_archive(file, self._anomaly_dir, ext)
+        extract_archive(file, self._anomaly_dir, mime)
 
     def _purge_cache(self) -> None:
         print("[+] Purging Anomaly archives")


### PR DESCRIPTION
This PR aims to fix #85 where Anomaly installs would fail due to a mismatch in parameter names. This was caused by the caller using a new parameter name that wasn't reflected in the method's signature (potentially someone forgot to stage & commit it 😅)

This fix has been tested locally, with the installer getting past the download and into the extraction.