### PR TITLE
Force registration of `Retrogue's Additional Weapons` mod.

### DIFF
--- a/launcher/mods/__init__.py
+++ b/launcher/mods/__init__.py
@@ -89,4 +89,14 @@ def read_mod_maker(mod_path: Path) -> List[Base]:
         'info_url': 'https://github.com/Grokitach/gamma_large_files_v2',
     })
 
+    # In the list but don't have info_url so this is ignored.
+    register_git_mod(git_mods, **{
+        'name': 'Retrogue\'s Additional Weapons',
+        'url': 'https://www.moddb.com/addons/start/222467',
+        'install_directives': None,
+        'author': 'Retrogue',
+        'title': 'Retrogue\'s Additional Weapons',
+        'info_url': 'https://github.com/Grokitach/gamma_large_files_v2',
+    })
+
     return git_mods + result


### PR DESCRIPTION
Since info_url is missing from **modpack_maker_list.txt** launcher ignore git install and continue as a classic mod installation.

Forcing registration as a git mod (gamma_large_file) should take care on the issue.

Yes it will exist twice (Git + classic), but adding a sound file in the mod folder should not break everything.