### PR TITLE
Getting rid of `rarfile.RarFile.extractall()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ You are missing a tool that extracts RAR files. You can use something like `unra
 - On Fedora **(RPM Fusion required)**: `sudo dnf install unrar`. Note that before the installation you will need to enable the **non-free** RPM Fusion repository since the default package provided by Fedora will cause problems. [Instructions on how to enable it here](https://rpmfusion.org/Configuration).
 - On Arch/Manjaro: `sudo pacman -S unrar`
 
+### SevenZipDecompressionError
+
+7zip seems to have trouble with this archive, if this is a rar file, make sure to install `7z` with rar capabilities.
+- On Ubuntu/Debian: `sudo apt install 7zip-rar`
+
 ### Something else ?
 
 Well .... you're alone kid. Good luck. Try downgrading DirectX version or looking at log file.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ You are missing a tool that extracts RAR files. You can use something like `unra
 7zip seems to have trouble with this archive, if this is a rar file, make sure to install `7z` with rar capabilities.
 - On Ubuntu/Debian: `sudo apt install 7zip-rar`
 
+You can use `rarfile` module for decompressing by setting **GAMMA_LAUNCHER_USE_RARFILE** env.
+Warning: This may be slow for some archive
+
 ### Something else ?
 
 Well .... you're alone kid. Good luck. Try downgrading DirectX version or looking at log file.

--- a/launcher/archive.py
+++ b/launcher/archive.py
@@ -10,6 +10,10 @@ from typing import List
 from zipfile import ZipFile
 
 
+class SevenZipDecompressionError(Exception):
+    pass
+
+
 def get_mime_from_file(filename) -> str:
     with open(filename, 'rb') as f:
         d = f.read(16)
@@ -27,11 +31,13 @@ def get_mime_from_file(filename) -> str:
     return 'Unknown'
 
 
+def _7zip_extract(f: str, p: str) -> None:
+    if run(['7z', 'x', '-y', f'-o{p}', f]).returncode != 0:
+        raise SevenZipDecompressionError(f'7z error will decompressing {f}')
+
+
 if os_name == 'nt':
     from os import environ, getenv, pathsep
-
-    class Win32ExtractError(Exception):
-        pass
 
     # Adding default 7-Zip path or user defined to PATH
     if getenv('LAUNCHER_WIN32_7Z_PATH'):
@@ -44,30 +50,18 @@ if os_name == 'nt':
             }
         )
 
-    def _win32_extract(f: str, p: str) -> None:
-        if run(['7z', 'x', '-y', f'-o{p}', f], shell=True).returncode != 0:
-            raise Win32ExtractError(
-                f'Error while decompressing with 7z file: {f}\n'
-                'Make sure 7z is installed in default path, if not use '
-                'LAUNCHER_WIN32_7Z_PATH to set it'
-            )
-
     _extract_func_dict = {
-        'application/x-7z-compressed': _win32_extract,
-        'application/x-rar': _win32_extract,
-        'application/zip': _win32_extract,
-        'application/x-7z-compressed+bcj2': _win32_extract,
+        'application/x-7z-compressed': _7zip_extract,
+        'application/x-rar': _7zip_extract,
+        'application/zip': _7zip_extract,
+        'application/x-7z-compressed+bcj2': _7zip_extract,
     }
 else:
-    def _7zip_bcj2_workaround(f: str, p: str) -> None:
-        if run(['7z', 'x', '-y', f'-o{p}', f]).returncode != 0:
-            raise RuntimeError(f'7z error will decompressing {f}')
-
     _extract_func_dict = {
         'application/x-7z-compressed': lambda f, p: SevenZipFile(f).extractall(p),
-        'application/x-rar': lambda f, p: RarFile(f).extractall(p),
+        'application/x-rar': _7zip_extract,
         'application/zip': lambda f, p: ZipFile(f).extractall(p),
-        'application/x-7z-compressed+bcj2': _7zip_bcj2_workaround
+        'application/x-7z-compressed+bcj2': _7zip_extract
     }
 
 

--- a/launcher/archive.py
+++ b/launcher/archive.py
@@ -2,7 +2,7 @@ from distutils.dir_util import copy_tree
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from os import name as os_name
+from os import getenv, name as os_name
 from subprocess import run
 from py7zr import SevenZipFile
 from rarfile import RarFile
@@ -37,7 +37,7 @@ def _7zip_extract(f: str, p: str) -> None:
 
 
 if os_name == 'nt':
-    from os import environ, getenv, pathsep
+    from os import environ, pathsep
 
     # Adding default 7-Zip path or user defined to PATH
     if getenv('LAUNCHER_WIN32_7Z_PATH'):
@@ -59,7 +59,9 @@ if os_name == 'nt':
 else:
     _extract_func_dict = {
         'application/x-7z-compressed': lambda f, p: SevenZipFile(f).extractall(p),
-        'application/x-rar': _7zip_extract,
+        'application/x-rar':
+        _7zip_extract if getenv('GAMMA_LAUNCHER_USE_RARFILE', None) is None else
+        lambda f, p: RarFile(f).extractall(p),
         'application/zip': lambda f, p: ZipFile(f).extractall(p),
         'application/x-7z-compressed+bcj2': _7zip_extract
     }


### PR DESCRIPTION
Resolve #127 