### PR TITLE
Add support for custom G.A.M.M.A repository

### DIFF
--- a/launcher/commands/install.py
+++ b/launcher/commands/install.py
@@ -181,6 +181,12 @@ def _create_full_install_args() -> Dict:
             "dest": "custom_def",
             "default": None,
         },
+        "--custom-gamma-repository": {
+            "help": "Set a custom repository for S.T.A.L.K..E.R.: G.A.M.M.A.",
+            "type": str,
+            "dest": "custom_repo",
+            "default": 'Grokitach/Stalker_GAMMA',
+        },
         "--no-def-update": {
             "help": "Do not update S.T.A.L.K..E.R.: G.A.M.M.A. definition",
             "action": "store_false",
@@ -215,6 +221,7 @@ class FullInstall:
         self._dl_dir = None
         self._mod_dir = None
         self._grok_mod_dir = None
+        self._repo = None
 
     def _update_gamma_definition(self, *args) -> None:
         print('[+] Updating G.A.M.M.A. definition')
@@ -227,7 +234,7 @@ class FullInstall:
                 return
 
             r_version = g_session.get(
-                'https://raw.githubusercontent.com/Grokitach/Stalker_GAMMA/main/G.A.M.M.A_definition_version.txt'
+                f'https://raw.githubusercontent.com/{self._repo}/main/G.A.M.M.A_definition_version.txt'
             ).text.strip()
             if int(r_version) > int(l_version):
                 gdef.unlink()
@@ -237,7 +244,7 @@ class FullInstall:
 
         if not gdef.is_file():
             print('    downloading archive...')
-            g = get_handler_for_url("https://github.com/Grokitach/Stalker_GAMMA/archive/refs/heads/main.zip")
+            g = get_handler_for_url(f"https://github.com/{self._repo}/archive/refs/heads/main.zip")
             g.download(gdef)
 
         extract_git_archive(gdef, self._grok_mod_dir, 'Stalker_GAMMA-main')
@@ -251,7 +258,7 @@ class FullInstall:
         print(f'[+] Setting custom G.A.M.M.A. definition to: {rev}')
         gdef = self._grok_mod_dir / 'GAMMA_definition.zip'
 
-        g = get_handler_for_url(f'https://github.com/Grokitach/Stalker_GAMMA/archive/{rev}.zip')
+        g = get_handler_for_url(f'https://github.com/{self._repo}/archive/{rev}.zip')
         g.download(gdef)
 
         extract_git_archive(gdef, self._grok_mod_dir)
@@ -322,6 +329,8 @@ AutomaticArchiveInvalidation=false
             GammaSetup().run(args)
 
         # Start installing
+        self._repo = args.custom_repo
+
         if args.update_def:
             (self._update_gamma_definition if not args.custom_def else self._set_custom_gamma_def)(args.custom_def)
         if args.anomaly_patch:


### PR DESCRIPTION
Ability to use custom G.A.M.M.A repository from Github
I don't think there are other sites with forks so for now only Github support