### PR TITLE
Str call on errors

### DIFF
--- a/launcher/commands/check.py
+++ b/launcher/commands/check.py
@@ -81,6 +81,6 @@ class CheckMD5:
             except (HashError, ModDBDownloadError) as e:
                 errors.append(str(e))
 
-        print("\n".join(errors))
+        print("\n".join([str(error) for error in errors])) 
 
         sys.exit(0 if not errors else 1)


### PR DESCRIPTION
Ran error array through str before concat so that it can actually print

Error shown:
![image](https://github.com/user-attachments/assets/b06ec9df-de73-4b78-a56b-6c2da90755d4)
