### PR TITLE
Return sorted path set to avoid undefined behavior

### DIFF
--- a/launcher/mods/installer/git.py
+++ b/launcher/mods/installer/git.py
@@ -28,7 +28,7 @@ class GitInstaller(DefaultInstaller):
         for i in folder_to_install:
             tmp += [v.parent for v in pdir.glob(f"**/{i}")]
 
-        return set(tmp)
+        return sorted(set(tmp))
 
     def append(self, **kwargs) -> None:
         self.mods.append(kwargs)


### PR DESCRIPTION
Resolves #183 #189

**w_sig550.ltx** & **w_sig552.ltx** have 2 sources:

https://github.com/Grokitach/teivaz_anomaly_gunslinger/tree/main/SIG550/Sig%20Replacer/gamedata/configs/items/weapons https://github.com/Grokitach/teivaz_anomaly_gunslinger/tree/main/SIG550/B%26S%20Patch%20%5BUse%20only%20if%20you%20have%20B%26S!%5D/gamedata/configs/items/weapons

To make installation functional, *Sig Replacer* one have to be used. Just sorting the set will make sure of this since `'B&S Path' < 'Sig Replacer'`

**Sig Replacer** will now overwrite constantly the one from **B&S Patch** and fix the "sometimes it will, sometimes it won't" error.