### PR TITLE
Added display of source URL of download for Debug/Troubleshooting + minor gitignore change.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/__pycache__
+build/
+gamma_launcher.egg-info/

--- a/launcher/mods/downloader/base.py
+++ b/launcher/mods/downloader/base.py
@@ -50,7 +50,7 @@ class DefaultDownloader:
                 return self._archive
 
         with open(self._archive, "wb") as f, tqdm(
-            desc=f"  - Downloading {self._archive.name}",
+            desc=f"  - Downloading {self._archive.name} ({self._url})",
             unit="iB", unit_scale=True, unit_divisor=1024
         ) as progress:
             r = g_session.get(self._url, stream=True)


### PR DESCRIPTION
So I'm debugging [this](https://pastebin.com/59GZ70R6) right now, being able to see from where launcher is downloading files will make life easier for everyone, user can try to download files manually to see is problem is in their network or if problem/error gamma-launcher related.

`.gitignore` part is self-explanatory.