### PR TITLE
So there was some fuss that gamma-launcher is dangerous cuz AUR deps are vulnerable and it is not clearly stated that AUR is unofical, fixing it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ Use the `--cache-directory` option to re-use previously downloaded files.
 
 ### Using AUR (Arch Linux)
 
-On Arch Linux and Arch-based operating systems, you can download package from AUR:  
+(DANGEROUS, NOT OFFICIALLY SUPPORTED) On Arch Linux and Arch-based operating systems, you can download package from AUR:  
 
 `yay -S gamma-launcher`  
+
+AUR package has vulnerable (8.8 RCE) dependencie (js2py-0.74 https://nvd.nist.gov/vuln/detail/CVE-2024-28397)
+
+Use on your own risk!
 
 Or you can build it by yourself:
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,9 @@ Use the `--cache-directory` option to re-use previously downloaded files.
 
 ### Using AUR (Arch Linux)
 
-**(DANGEROUS, NOT OFFICIALLY SUPPORTED)** On Arch Linux and Arch-based operating systems, you can download package from AUR:  
+**(NOT OFFICIALLY SUPPORTED)** On Arch Linux and Arch-based operating systems, you can download package from AUR:  
 
 `yay -S gamma-launcher`  
-
-**AUR package has vulnerable (8.8 RCE) dependencie (js2py-0.74 https://nvd.nist.gov/vuln/detail/CVE-2024-28397)**
 
 Use at your own risk!
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Use the `--cache-directory` option to re-use previously downloaded files.
 
 ### Using AUR (Arch Linux)
 
-(DANGEROUS, NOT OFFICIALLY SUPPORTED) On Arch Linux and Arch-based operating systems, you can download package from AUR:  
+**(DANGEROUS, NOT OFFICIALLY SUPPORTED)** On Arch Linux and Arch-based operating systems, you can download package from AUR:  
 
 `yay -S gamma-launcher`  
 
-AUR package has vulnerable (8.8 RCE) dependencie (js2py-0.74 https://nvd.nist.gov/vuln/detail/CVE-2024-28397)
+**AUR package has vulnerable (8.8 RCE) dependencie (js2py-0.74 https://nvd.nist.gov/vuln/detail/CVE-2024-28397)**
 
 Use on your own risk!
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use the `--cache-directory` option to re-use previously downloaded files.
 
 **AUR package has vulnerable (8.8 RCE) dependencie (js2py-0.74 https://nvd.nist.gov/vuln/detail/CVE-2024-28397)**
 
-Use on your own risk!
+Use at your own risk!
 
 Or you can build it by yourself:
 


### PR DESCRIPTION
Clearly stating in README that AUR package is third party and has vulnerable dep.