### PR TITLE
Handle BCJ2 unsupported compression

### DIFF
--- a/launcher/mods/archive.py
+++ b/launcher/mods/archive.py
@@ -40,7 +40,6 @@ if system() == 'Windows':
         'application/x-7z-compressed': _win32_extract,
         'application/x-rar': _win32_extract,
         'application/zip': _win32_extract,
-        'application/x-7z-compressed+bcj2': _win32_extract,
     }
 else:
     def _7zip_bcj2_workaround(f: str, p: str) -> None:
@@ -59,7 +58,6 @@ else:
         'application/x-7z-compressed': _7zip_extractall,
         'application/x-rar': lambda f, p: RarFile(f'{f}').extractall(f'{p}'),
         'application/zip': lambda f, p: ZipFile(f).extractall(p),
-        'application/x-7z-compressed+bcj2': _7zip_bcj2_workaround
     }
 
 


### PR DESCRIPTION
While doing a full install of Anomaly and GAMMA some archives fail to extract due to BCJ2 compression being unsupported by py7zr. See error below for details.

I noticed that there is some code in `archive.py` that should handle those kinds of situations. However, as far as I can see mime type `application/x-7z-compressed+bcj2`is never defined for any archive. Instead of trying to detect archives containing bcj2 compressed files, I catch the error and try to decompress the archive using the 7z binary (which was already the implementation for handling this situation).

```
Calculating hash of Item_Model_Drop.11.7z: 100%|##########| 50.9M/50.9M [00:00<00:00, 741MiB/s]
Traceback (most recent call last):
  File "gamma-launcher.py", line 8, in <module>
  File "launcher/cli.py", line 115, in main
  File "launcher/commands/install.py", line 317, in run
  File "launcher/commands/install.py", line 266, in _install_mods
  File "launcher/mods/installer/default.py", line 68, in install
  File "launcher/mods/tempfile.py", line 50, in __enter__
  File "launcher/mods/downloader/base.py", line 66, in extract
  File "launcher/mods/archive.py", line 59, in extract_archive
  File "launcher/mods/archive.py", line 50, in <lambda>
  File "py7zr/py7zr.py", line 1023, in extractall
  File "py7zr/py7zr.py", line 627, in _extract
  File "py7zr/py7zr.py", line 1338, in extract
  File "py7zr/py7zr.py", line 1363, in extract_single
  File "py7zr/py7zr.py", line 1433, in _extract_single
  File "py7zr/py7zr.py", line 1488, in decompress
  File "py7zr/archiveinfo.py", line 442, in get_decompressor
  File "py7zr/compressor.py", line 608, in __init__
  File "py7zr/compressor.py", line 608, in <listcomp>
  File "py7zr/compressor.py", line 1124, in is_native_coder
  File "py7zr/compressor.py", line 1175, in raise_unsupported_method_id
py7zr.exceptions.UnsupportedCompressionMethodError: (b'\x03\x03\x01\x1b', 'BCJ2 filter is not supported by py7zr. Please consider to contribute to XZ/liblzma project and help Python core team implementing it. Or please use another tool to extract it.')
[PYI-7368:ERROR] Failed to execute script 'gamma-launcher' due to unhandled exception!
[+] Installing mod: Items Model Drop After Usage
Extracting /home/flow/Games/stalker-gamma-2/drive_c/Gamma/downloads/Item_Model_Drop.11.7z
Monitored process exited.
Initial process has exited (return code: 256)
All processes have quit
Exit with return code 256
2025-09-13 10:52:02,662: Command exited with code 256
2025-09-13 10:52:02,663: Error handling timeout function: Command exited with code 256
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/lutris/exception_backstops.py", line 79, in error_wrapper
    return handler(*args, **kwargs)
  File "/usr/lib/python3.13/site-packages/lutris/util/jobs.py", line 131, in wrapper
    repeat = func(*a, **kw)
  File "/usr/lib/python3.13/site-packages/lutris/installer/commands.py", line 439, in _monitor_task
    raise ScriptingError(_("Command exited with code %s") % command.return_code)
lutris.installer.errors.ScriptingError: Command exited with code 256
```