### PR TITLE
feat: add --gamma-branch flag for installing from non-default branches

### DIFF
--- a/launcher/commands/install.py
+++ b/launcher/commands/install.py
@@ -157,6 +157,12 @@ def _create_full_install_args() -> Dict:
             "dest": "custom_def",
             "default": None,
         },
+        "--gamma-branch": {
+            "help": "Target a specific branch of the G.A.M.M.A. repository (e.g., dev2 for 0.9.5)",
+            "type": str,
+            "dest": "gamma_branch",
+            "default": None,
+        },
         "--custom-gamma-repository": {
             "help": "Set a custom repository for S.T.A.L.K..E.R.: G.A.M.M.A.",
             "type": str,
@@ -198,12 +204,13 @@ class FullInstall:
         self._mod_dir = None
         self._grok_mod_dir = None
         self._repo = None
+        self._gamma_branch = None
 
     def _update_gamma_definition(self, *args) -> None:
         print('[+] Updating G.A.M.M.A. definition')
 
         rev_file = self._grok_mod_dir / 'revision.txt'
-        g = GithubArchive(f'https://github.com/{self._repo}')
+        g = GithubArchive(f'https://github.com/{self._repo}', branch=self._gamma_branch)
         g.download(self._dl_dir, use_cached=True)
 
         try:
@@ -316,6 +323,7 @@ AutomaticArchiveInvalidation=false
 
         # Start installing
         self._repo = args.custom_repo
+        self._gamma_branch = args.gamma_branch
 
         if args.update_def:
             (self._update_gamma_definition if not args.custom_def else self._set_custom_gamma_def)(args.custom_def)

--- a/launcher/mods/__init__.py
+++ b/launcher/mods/__init__.py
@@ -17,8 +17,11 @@ class ModDefault(DefaultInstaller):
 
 class BaseArchive(BaseInstaller):
 
-    def __init__(self, url: str) -> None:
-        super().__init__(ModInfo({"url": url}))
+    def __init__(self, url: str, branch: str = None) -> None:
+        data = {"url": url}
+        if branch is not None:
+            data["branch"] = branch
+        super().__init__(ModInfo(data))
 
 
 GithubArchive = BaseArchive  # For compat: DownloaderFactory will instanciate correct handler

--- a/launcher/mods/downloader/__init__.py
+++ b/launcher/mods/downloader/__init__.py
@@ -26,6 +26,6 @@ def DownloaderFactory(info: ModInfo) -> Optional[DefaultDownloader | GithubDownl
         return ModDBDownloader(info.url, info.iurl)
 
     if 'github.com' in info.url and not info.url.endswith(('.zip', '.7z', '.rar')):
-        return GithubDownloader(info.url)
+        return GithubDownloader(info.url, branch=info.branch)
 
     return DefaultDownloader(info.url, *(info.args or ()))

--- a/launcher/mods/downloader/github/git.py
+++ b/launcher/mods/downloader/github/git.py
@@ -7,7 +7,6 @@ from tqdm import tqdm
 from typing import Optional
 
 from launcher.bootstrap import is_in_pyinstaller_context
-from launcher.mods.info import ModInfo
 from launcher.mods.downloader.base import DefaultDownloader
 
 if getenv("GAMMA_LAUNCHER_NO_GIT", None):
@@ -38,16 +37,17 @@ class ProgressPrinter(RemoteProgress):
 class GithubDownloader(DefaultDownloader):
     "Specialization of `launcher.mods.downloader.base.DefaultDownloader` to manage Github URLs"
 
-    def __init__(self, info: ModInfo) -> None:
-        super().__init__(info)
+    def __init__(self, url: str, branch: str = None) -> None:
+        super().__init__(url)
         self._user = None
         self._project = None
         self._revision = None
+        self._branch = branch
 
     def _set_vars(self, to: Path) -> None:
         self._user, self._project, *_, revision = self.regexp_url.match(self._url).groups()
         self._archive = to / f"{self._project}.git"
-        self._revision = revision if revision else f"{self._user}/main"
+        self._revision = revision if revision else f"{self._user}/{self._branch or 'main'}"
 
     def check(self, to: Path, update_cache: bool = False) -> None:
         pass

--- a/launcher/mods/downloader/github/legacy.py
+++ b/launcher/mods/downloader/github/legacy.py
@@ -4,7 +4,6 @@ from tempfile import TemporaryDirectory
 from typing import Optional
 
 from launcher.archive import extract_archive
-from launcher.mods.info import ModInfo
 from launcher.mods.downloader.base import DefaultDownloader, g_session
 
 
@@ -13,9 +12,10 @@ class GithubDownloader(DefaultDownloader):
     to manage Github URLs without `GitPython` module
     """
 
-    def __init__(self, info: ModInfo) -> None:
-        super().__init__(info)
+    def __init__(self, url: str, branch: str = None) -> None:
+        super().__init__(url)
         self._revision = None
+        self._branch = branch
 
     def check(self, to: Path, update_cache: bool = False) -> None:
         pass
@@ -28,7 +28,7 @@ class GithubDownloader(DefaultDownloader):
             self._archive = to / (filename or f"{project}-{self._revision}.zip")
             return super().download(to, use_cached)
 
-        branch = g_session.get(
+        branch = self._branch or g_session.get(
             f"https://api.github.com/repos/{user}/{project}",
             headers={"Accept": "application/json"}
         ).json()["default_branch"]

--- a/launcher/mods/info.py
+++ b/launcher/mods/info.py
@@ -42,3 +42,6 @@ class ModInfo:
     @property
     def args(self) -> Optional[Tuple[str]]:
         return self._data.get('args', None)
+    @property
+    def branch(self) -> Optional[str]:
+        return self._data.get('branch', None)

--- a/tests/test_mods_downloader.py
+++ b/tests/test_mods_downloader.py
@@ -39,3 +39,69 @@ class DownloaderFactoryTestCase(TestCase):
     def test_default_with_args(self):
         o = DownloaderFactory(self._info_with_args)
         self.assertIsInstance(o, DefaultDownloader)
+
+    def test_github_downloader_receives_branch(self):
+        """Verify branch is forwarded from ModInfo to GithubDownloader."""
+        info = ModInfo({'url': 'https://github.com/Mord3rca/gamma-launcher', 'branch': 'dev2'})
+
+        # We can't fully instantiate the real downloader without network/git,
+        # so we verify the factory passes the branch argument correctly.
+        # Instead, test that DownloaderFactory calls GithubDownloader with the branch kwarg.
+        # We do this by patching the GithubDownloader constructor.
+        import launcher.mods.downloader as mod
+        from unittest.mock import patch
+
+        with patch.object(mod, 'GithubDownloader', wraps=mod.GithubDownloader) as mock_dl:
+            mod.DownloaderFactory(info)
+            mock_dl.assert_called_once_with(info.url, branch='dev2')
+
+
+class GithubDownloaderGitBranchTestCase(TestCase):
+    """Tests for branch support in git.py GithubDownloader."""
+
+    def test_defaults_to_main_when_branch_none(self):
+        from launcher.mods.downloader.github.git import GithubDownloader as GitDL
+        dl = GitDL("https://github.com/foo/bar")
+        self.assertIsNone(dl._branch)
+
+    def test_stores_branch_when_provided(self):
+        from launcher.mods.downloader.github.git import GithubDownloader as GitDL
+        dl = GitDL("https://github.com/foo/bar", branch="dev2")
+        self.assertEqual(dl._branch, "dev2")
+
+    def test_set_vars_uses_branch(self):
+        """Verify _set_vars resolves to the correct branch reference."""
+        from launcher.mods.downloader.github.git import GithubDownloader as GitDL
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            to = Path(tmp)
+            dl = GitDL("https://github.com/foo/bar", branch="dev2")
+            dl._set_vars(to)
+            self.assertEqual(dl._revision, "foo/dev2")
+
+    def test_set_vars_defaults_main(self):
+        from launcher.mods.downloader.github.git import GithubDownloader as GitDL
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            to = Path(tmp)
+            dl = GitDL("https://github.com/foo/bar")
+            dl._set_vars(to)
+            self.assertEqual(dl._revision, "foo/main")
+
+
+class GithubDownloaderLegacyBranchTestCase(TestCase):
+    """Tests for branch support in legacy.py GithubDownloader."""
+
+    def test_stores_branch_when_provided(self):
+        from launcher.mods.downloader.github.legacy import GithubDownloader as LegacyDL
+        dl = LegacyDL("https://github.com/foo/bar", branch="dev2")
+        self.assertEqual(dl._branch, "dev2")
+
+    def test_defaults_to_none_when_not_provided(self):
+        from launcher.mods.downloader.github.legacy import GithubDownloader as LegacyDL
+        dl = LegacyDL("https://github.com/foo/bar")
+        self.assertIsNone(dl._branch)

--- a/tests/test_mods_info.py
+++ b/tests/test_mods_info.py
@@ -76,3 +76,11 @@ class ModInfoTestCase(TestCase):
 
         m.name = new_name
         self.assertEqual(m.name, new_name, 'Invalid name after set')
+
+    def test_branch_not_set(self):
+        m = ModInfo({})
+        self.assertIsNone(m.branch)
+
+    def test_branch_set(self):
+        m = ModInfo({'branch': 'dev2'})
+        self.assertEqual(m.branch, 'dev2')


### PR DESCRIPTION
Adds `--gamma-branch` CLI arg for installing mods from non-default branches. Plumbs through ModInfo, downloader factory, and both GitHub downloaders. Enables prerelease installs.

**Single commit:** `28f10be`
- Add `--gamma-branch` CLI arg to `full-install` command
- Plumb branch through `ModInfo.branch` property
- Forward branch in `DownloaderFactory` to `GithubDownloader`/`GithubGitDownloader`
- Both git and legacy downloaders prefer explicit branch over auto-resolved default
- Enables installing prerelease versions from non-default branches
- Add tests for `ModInfo.branch`, `DownloaderFactory` forwarding, both downloader implementations

⚠️ **Not reliably tested — worked for me on one run.**