### PR TITLE
fix: use project-local tmpdir for large extractions and retry failed downloads

### DIFF
--- a/launcher/archive.py
+++ b/launcher/archive.py
@@ -101,3 +101,30 @@ def list_archive_content(filename: str, mime: str = None) -> List[str]:
         'application/x-rar': lambda f: RarFile(f).namelist(),
         'application/zip': lambda f: ZipFile(f).namelist(),
     }.get(mime)(filename)
+ 
+ 
+def get_archive_uncompressed_size(filename: str, mime: str = None) -> int:
+    """Get total uncompressed size of all files in an archive (in bytes).
+
+    Argument(s):
+    * filename -- File path of the archive
+
+    Keyword argument(s):
+    * mime -- Set a MIME type instead of determining it with `get_mime_from_file`
+
+    Return the sum of each file's uncompressed size. Does NOT include
+    filesystem overhead (directory entries, metadata).
+    """
+    mime = mime or get_mime_from_file(filename)
+    if mime == 'application/x-7z-compressed':
+        with SevenZipFile(filename) as archive:
+            return archive.archiveinfo().uncompressed
+    if mime == 'application/x-rar':
+        with RarFile(filename) as archive:
+            return sum(f.file_size for f in archive.infolist())
+    if mime == 'application/zip':
+        with ZipFile(filename) as archive:
+            return sum(f.file_size for f in archive.infolist())
+    raise RuntimeError(
+        f'Cannot get uncompressed size for {filename}: unknown type {mime}'
+    )

--- a/launcher/commands/install.py
+++ b/launcher/commands/install.py
@@ -9,6 +9,7 @@ from launcher.common import anomaly_arg, gamma_arg, cache_dir_arg
 
 from launcher.mods import BaseArchive, GithubArchive, GitResource, ModDBArchive, read_mod_maker
 from launcher.userltx import UserLTX
+from launcher.tempfile import scoped_tempdir
 
 
 guide_url: str = "https://github.com/DravenusRex/stalker-gamma-linux-guide"
@@ -27,8 +28,8 @@ def check_tmp_free_space(size: int) -> None:
         _, __, free = disk_usage(dir)
         if free < (size * 1024 * 1024 * 1024):
             raise RuntimeError(
-                f"You need at least {size} GiB of space in TMPDIR for this to work.\n"
-                "Please export TMPDIR to a folder with enough space available."
+                f"You need at least {size} GiB of space in the temporary directory for this to work.\n"
+                "Please ensure the temporary directory has enough space available."
             )
 
 
@@ -295,8 +296,6 @@ AutomaticArchiveInvalidation=false
 """)
 
     def run(self, args):
-        check_tmp_free_space(6)
-
         # Init paths
         self._anomaly_dir = Path(args.anomaly).expanduser()
         self._gamma_dir = Path(args.gamma).expanduser()
@@ -308,23 +307,26 @@ AutomaticArchiveInvalidation=false
         # Make sure folder are existing
         self._dl_dir.mkdir(parents=True, exist_ok=True)
 
-        if not (self._anomaly_dir / "bin").is_dir():
-            AnomalyInstall().run(args)
+        # Use project-local tmpdir on the main filesystem (not /tmp tmpfs)
+        # to avoid filling tmpfs during extraction of large archives.
+        with scoped_tempdir(str(self._gamma_dir)):
+            if not (self._anomaly_dir / "bin").is_dir():
+                AnomalyInstall().run(args)
 
-        if not (self._mod_dir.is_dir() and self._grok_mod_dir.is_dir()):
-            GammaSetup().run(args)
+            if not (self._mod_dir.is_dir() and self._grok_mod_dir.is_dir()):
+                GammaSetup().run(args)
 
-        # Start installing
-        self._repo = args.custom_repo
+            # Start installing
+            self._repo = args.custom_repo
 
-        if args.update_def:
-            (self._update_gamma_definition if not args.custom_def else self._set_custom_gamma_def)(args.custom_def)
-        if args.anomaly_patch:
-            self._patch_anomaly(args.preserve_user_config)
+            if args.update_def:
+                (self._update_gamma_definition if not args.custom_def else self._set_custom_gamma_def)(args.custom_def)
+            if args.anomaly_patch:
+                self._patch_anomaly(args.preserve_user_config)
 
-        self._install_mods()
-        self._install_git_resources()
-        self._install_modorganizer_profile()
-        self._copy_gamma_modpack()
+            self._install_mods()
+            self._install_git_resources()
+            self._install_modorganizer_profile()
+            self._copy_gamma_modpack()
 
-        print('[+] Setup ended... Enjoy your journey in the Zone o/')
+            print('[+] Setup ended... Enjoy your journey in the Zone o/')

--- a/launcher/exceptions.py
+++ b/launcher/exceptions.py
@@ -4,3 +4,8 @@ class HashError(Exception):
 
 class ModDBDownloadError(Exception):
     pass
+
+
+class InsufficientSpaceError(RuntimeError):
+    """Raised when there is not enough disk space for extraction."""
+    pass

--- a/launcher/mods/downloader/base.py
+++ b/launcher/mods/downloader/base.py
@@ -1,5 +1,6 @@
 ""
 from cloudscraper import create_scraper
+from shutil import disk_usage
 from os.path import basename
 from pathlib import Path
 from re import compile
@@ -9,9 +10,9 @@ from tqdm import tqdm
 from urllib.parse import urlparse
 
 from launcher import __version__
-from launcher.exceptions import HashError
+from launcher.exceptions import HashError, InsufficientSpaceError
 from launcher.hash import check_hash
-from launcher.archive import extract_archive
+from launcher.archive import extract_archive, get_archive_uncompressed_size
 
 g_session = create_scraper(
     browser={
@@ -40,6 +41,13 @@ class DefaultDownloader:
         self._archivehash = filehash
 
         self._user_wanted_name = filename
+
+    def _pre_download_hook(self) -> None:
+        """Hook called before each download attempt (including retries).
+
+        Override in subclasses to refresh download URLs between retry attempts.
+        """
+        pass
 
     def _set_archive_name(self, to: Path) -> None:
         if self._archive:
@@ -119,6 +127,7 @@ class DefaultDownloader:
         Return a `pathlib.Path` object like `self.archive`
         """
         self._set_archive_name(to)
+        self._pre_download_hook()
 
         hash = hash or self._archivehash
 
@@ -142,9 +151,28 @@ class DefaultDownloader:
         return self._archive
 
     def extract(self, to: Path) -> None:
-        """Extract the dowloaded archive
+        """Extract the downloaded archive
 
         Argument(s):
         * to -- Path object pointing to the directory to use for extraction
         """
+
+        # Check available space before extracting
+        try:
+            uncompressed = get_archive_uncompressed_size(str(self.archive))
+            _, _, free = disk_usage(to)
+            # 10% buffer for decompression overhead; see archive.py docstring
+            needed = int(uncompressed * 1.1)
+            if free < needed:
+                raise InsufficientSpaceError(
+                    f'Not enough space to extract {self.archive.name}: '
+                    f'~{uncompressed / 1024**3:.1f} GiB needed, '
+                    f'only {free / 1024**3:.1f} GiB available'
+                )
+        except InsufficientSpaceError:
+            raise
+        except (RuntimeError, OSError, ValueError):
+            # Can't determine size (e.g. unknown archive type or corrupted file)
+            pass
+
         extract_archive(self.archive, to)

--- a/launcher/mods/downloader/moddb.py
+++ b/launcher/mods/downloader/moddb.py
@@ -14,6 +14,7 @@ class ModDBDownloader(DefaultDownloader):
 
     def __init__(self, url: str, iurl: str) -> None:
         super().__init__(url)
+        self._moddb_start_url = url
         self._iurl = iurl
 
     @staticmethod
@@ -53,6 +54,15 @@ class ModDBDownloader(DefaultDownloader):
 
         return g_session.get(f"https://www.moddb.com{s[0]}", allow_redirects=False).headers["location"]
 
+
+    def _pre_download_hook(self) -> None:
+        """Re-resolve the ModDB mirror URL before each retry attempt.
+
+        ModDB returns different mirrors; a mirror that failed may be
+        replaced with a working one on the next request.
+        """
+        self._url = self._get_download_url(self._moddb_start_url)
+
     def _set_vars_from_metadata(self):
         if not self._iurl:
             return
@@ -88,6 +98,5 @@ class ModDBDownloader(DefaultDownloader):
 
     def download(self, to: Path, use_cached: bool = False, *args, **kwargs) -> Path:
         self._set_vars_from_metadata()
-        self._url = self._get_download_url(self._url)
 
         return super().download(to, use_cached)

--- a/launcher/tempfile.py
+++ b/launcher/tempfile.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 from platform import system
+from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 from typing import Callable
+import tempfile as _tempfile_mod
 
 from launcher.common import folder_to_install
 
@@ -40,6 +42,27 @@ class HotfixMalformedArchive:
             p = dir / path.name.replace('\\', '/')
             p.parent.mkdir(parents=True, exist_ok=True)
             path.rename(dir / p)
+
+@contextmanager
+def scoped_tempdir(base_dir: str):
+    """Context manager that redirects tempfile to a directory under *base_dir*.
+
+    Creates ``<base_dir>/.tmp`` if needed, sets ``tempfile.tempdir``
+    to it for the duration of the block, and restores the previous value on exit.
+
+    This avoids filling a small tmpfs (e.g. /tmp) during large extractions.
+
+    Argument(s):
+    * base_dir -- Root directory; temp files go in ``<base_dir>/.tmp``
+    """
+    tmp_path = Path(base_dir) / ".tmp"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    old = _tempfile_mod.tempdir
+    try:
+        _tempfile_mod.tempdir = str(tmp_path)
+        yield tmp_path
+    finally:
+        _tempfile_mod.tempdir = old
 
 
 tempDirHotfixes = (HotfixPathCase, HotfixMalformedArchive) if not system() == 'Windows' else ()

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 from typing import List
 from unittest import mock, TestCase, skipIf
 
-from launcher.archive import extract_archive, get_mime_from_file, list_archive_content
+from launcher.archive import extract_archive, get_mime_from_file, get_archive_uncompressed_size, list_archive_content
 
 from common import data_dir
 
@@ -74,3 +74,30 @@ class ListTestCase(TestCase):
         self._list_archive_test(data_dir / 'test-git-archive.zip', [
             'project-main/', 'project-main/flag'
         ])
+
+
+class UncompressedSizeTestCase(TestCase):
+
+    def _size_test(self, archive: Path, expected: int = 8) -> None:
+        size = get_archive_uncompressed_size(str(archive))
+        self.assertEqual(size, expected)
+
+    def test_size_7zip(self):
+        self._size_test(data_dir / 'test.7z')
+
+    def test_size_zip(self):
+        self._size_test(data_dir / 'test.zip')
+
+    def test_size_rar(self):
+        self._size_test(data_dir / 'test.rar')
+
+    def test_size_with_explicit_mime(self):
+        size = get_archive_uncompressed_size(
+            str(data_dir / 'test.zip'),
+            mime='application/zip',
+        )
+        self.assertEqual(size, 8)
+
+    def test_size_unknown_mime_raises(self):
+        with self.assertRaises(RuntimeError):
+            get_archive_uncompressed_size(str(data_dir / 'test.zip'), mime='application/x-bogus')

--- a/tests/test_mods_downloader_base.py
+++ b/tests/test_mods_downloader_base.py
@@ -1,12 +1,12 @@
 from hashlib import md5
 from requests.exceptions import ConnectionError, HTTPError
 from unittest import TestCase, skip
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from shutil import copy
 
-from launcher.exceptions import HashError
+from launcher.exceptions import HashError, InsufficientSpaceError
 from launcher.mods.downloader.base import DefaultDownloader
 
 from common import basic_url, data_dir, git_archive_url, mocked_get
@@ -139,3 +139,46 @@ class DefaultDownloaderTestCase(TestCase):
             o.download(Path(dir))
 
         self.assertEqual(len(mock_request.call_args_list), 3)
+
+
+class ExtractSpaceCheckTestCase(TestCase):
+    """Tests for the disk-space guard in DefaultDownloader.extract()."""
+
+    @patch('launcher.mods.downloader.base.extract_archive')
+    @patch('launcher.mods.downloader.base.disk_usage')
+    @patch('launcher.mods.downloader.base.get_archive_uncompressed_size')
+    def test_extracts_when_enough_space(self, mock_size, mock_du, mock_extract):
+        mock_size.return_value = 1000
+        mock_du.return_value = (0, 0, 2000)  # 2000 bytes free
+
+        o = DefaultDownloader(basic_url)
+        o._archive = Path('/fake/archive.zip')
+        o.extract(Path('/fake/dest'))
+
+        mock_extract.assert_called_once()
+
+    @patch('launcher.mods.downloader.base.extract_archive')
+    @patch('launcher.mods.downloader.base.disk_usage')
+    @patch('launcher.mods.downloader.base.get_archive_uncompressed_size')
+    def test_raises_insufficient_space(self, mock_size, mock_du, mock_extract):
+        mock_size.return_value = 2000
+        mock_du.return_value = (0, 0, 100)  # 100 bytes free, needs ~2200
+
+        o = DefaultDownloader(basic_url)
+        o._archive = Path('/fake/archive.zip')
+
+        with self.assertRaises(InsufficientSpaceError):
+            o.extract(Path('/fake/dest'))
+
+        mock_extract.assert_not_called()
+
+    @patch('launcher.mods.downloader.base.extract_archive')
+    @patch('launcher.mods.downloader.base.get_archive_uncompressed_size')
+    def test_skips_check_when_size_unknown(self, mock_size, mock_extract):
+        mock_size.side_effect = ValueError("not an archive")
+
+        o = DefaultDownloader(basic_url)
+        o._archive = Path('/fake/archive.zip')
+        o.extract(Path('/fake/dest'))
+
+        mock_extract.assert_called_once()


### PR DESCRIPTION
Scoped tempdir context manager, archive uncompressed size check, download retry hook for ModDB mirror re-resolution.

**Single commit:** `c03411f`
- Add retry hook to re-resolve download URLs on failure
- Use project-local tmpdir for large extractions to avoid /tmp space issues
- Add tests for archive size query and space guard
- Code review feedback incorporated

⚠️ **Not reliably tested — worked for me on one run.**